### PR TITLE
Research Menu Exit Button Change

### DIFF
--- a/UI/research_menu_components/research_menu.gd
+++ b/UI/research_menu_components/research_menu.gd
@@ -103,6 +103,7 @@ func _on_open_work_4_button_down() -> void:
 
 func _on_exit_button_down() -> void:
 	hide()
+	$ExitButton/Exit.hide()
 	if resource_box:
 		resource_box.show() 
 	for child in $HBoxContainer/VBoxContainer/Resources.get_children():
@@ -176,6 +177,7 @@ func update_pe_display() -> void:
 	
 func window_call(res: AbnormalityResource) -> void:
 	menu_open.emit()
+	$ExitButton/Exit.show()
 	anomaly = res
 	main_open_cost = anomaly.threat_level
 	action_open_cost = anomaly.threat_level

--- a/UI/research_menu_components/research_menu.tscn
+++ b/UI/research_menu_components/research_menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://gnrfrvcmqj0r"]
+[gd_scene load_steps=9 format=3 uid="uid://gnrfrvcmqj0r"]
 
 [ext_resource type="Script" uid="uid://6kufsop5afjp" path="res://UI/research_menu_components/research_menu.gd" id="1_6a0ui"]
 [ext_resource type="Texture2D" uid="uid://bcih7dqgynq6g" path="res://UI/research_menu_components/placeholderart.jpg" id="1_448q0"]
@@ -15,6 +15,14 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0.294118, 0.407843, 0.764706, 0.67451)
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rufiq"]
+bg_color = Color(0.44054, 0.00827069, 0.115605, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.698671, 0, 0.250641, 1)
+
 [node name="ResearchMenu" type="TabContainer"]
 custom_minimum_size = Vector2(1280, 720)
 anchors_preset = 15
@@ -28,6 +36,7 @@ current_tab = 0
 script = ExtResource("1_6a0ui")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
+z_index = 1
 layout_mode = 2
 metadata/_tab_index = 0
 
@@ -80,14 +89,6 @@ theme_override_styles/normal = ExtResource("3_sj57j")
 layout_mode = 2
 size_flags_vertical = 10
 size_flags_stretch_ratio = 1.6
-
-[node name="Exit" type="Button" parent="HBoxContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 8
-theme_override_styles/normal = SubResource("StyleBoxFlat_7g6qr")
-text = "Exit
-"
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="HBoxContainer"]
 layout_mode = 2
@@ -443,6 +444,7 @@ text = "Purchase:"
 
 [node name="Lore" type="HBoxContainer" parent="."]
 visible = false
+z_index = 1
 layout_mode = 2
 metadata/_tab_index = 1
 
@@ -479,8 +481,22 @@ theme_override_styles/normal = ExtResource("3_sj57j")
 text = "Nothing"
 autowrap_mode = 3
 
+[node name="ExitButton" type="Node2D" parent="."]
+z_index = -1
+
+[node name="Exit" type="Button" parent="ExitButton"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 1247.0
+offset_right = 1280.0
+offset_bottom = 31.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/normal = SubResource("StyleBoxFlat_rufiq")
+text = "X"
+
 [connection signal="button_down" from="HBoxContainer/VBoxContainer/OpenMain" to="." method="_on_open_main_button_down"]
-[connection signal="button_down" from="HBoxContainer/VBoxContainer/Exit" to="." method="_on_exit_button_down"]
 [connection signal="button_down" from="HBoxContainer/VBoxContainer2/GridContainer/OpenWork1" to="." method="_on_open_work_1_button_down"]
 [connection signal="button_down" from="HBoxContainer/VBoxContainer2/GridContainer/OpenWork2" to="." method="_on_open_work_2_button_down"]
 [connection signal="button_down" from="HBoxContainer/VBoxContainer2/GridContainer/OpenWork3" to="." method="_on_open_work_3_button_down"]
@@ -490,3 +506,4 @@ autowrap_mode = 3
 [connection signal="button_down" from="HBoxContainer/VBoxContainer3/Shop/OpenArmor" to="." method="_on_open_armor_button_down"]
 [connection signal="button_down" from="HBoxContainer/VBoxContainer3/BuyButtons/WeaponButtCont/BuyWeapon" to="." method="_on_buy_weapon_button_down"]
 [connection signal="button_down" from="HBoxContainer/VBoxContainer3/BuyButtons/ArmorButtCont/BuyArmor" to="." method="_on_buy_armor_button_down"]
+[connection signal="button_down" from="ExitButton/Exit" to="." method="_on_exit_button_down"]


### PR DESCRIPTION
## Description
Changing the exit button position from bottom-left to top-right in research menu

## Acceptance Criteria

Acceptance criteria:
Given anomaly menu
When player wanna close this menu
Then he will find this button at the right upper corner

## Testing & Verification

1. Step 1 - Opening research window goes without issues. Exit button shows at the right position
2. Step 2 - Clicking the button closes the whole research menu
3. Step 3 - Opening research window multiple times does not cause any issues

### Checklist

- [V] Code adheres to project style guidelines
- [V] New and existing tests pass
- [V] Necessary migrations or config changes included