### PR TITLE
Bug report fix (label ubder energy bar)

### DIFF
--- a/UI/energy-bar/canvas_layer.gd
+++ b/UI/energy-bar/canvas_layer.gd
@@ -6,19 +6,42 @@ extends CanvasLayer
 @onready var energy_bar = $Control/TextureProgressBar
 @onready var day_label  = $Control/DayLabel
 
+var current_day: int = 1
+
 func _ready() -> void:
+	#initialize the bar's maximum from the global quota and reset its current value
 	energy_bar.max_value = Global.energy_quota
+	energy_bar.set_energy(0)
+
 	Global.energy_changed.connect(fill)
+
+	#subscribe to day‑change if the signal exists in Global
+	#if Global.has_signal("day_changed"):
+		#Global.day_changed.connect(update_day)
+
+	# Show the initial day
+	update_day(current_day)
 
 
 func fill(current_quota: int) -> void:
 	energy_bar.animate_to(current_quota, anim_time)
 
+
 func _on_fill_button_pressed() -> void:
 	var target = energy_bar.value + step
 	energy_bar.animate_to(target, anim_time)
 
-# update the day counter
+
 func update_day(day: int) -> void:
+	#called when the day changes
+	#update the day label and reset the bar.
+	current_day = day
 	if day_label:
 		day_label.text = "Day %d" % day
+
+	# # Update max from global variable
+	# energy_bar.max_value = Global.energy_quota
+	# # Reset current energy value
+	# energy_bar.set_energy(0)
+	# # Emit energy reset so fill() animates bar back to zero
+	# Global.energy_changed.emit(0)

--- a/UI/energy-bar/canvas_layer.gd
+++ b/UI/energy-bar/canvas_layer.gd
@@ -1,47 +1,24 @@
 extends CanvasLayer
 
-@export var step: int = 10
+@export var step: int = 1
 @export var anim_time: float = 0.3
 
 @onready var energy_bar = $Control/TextureProgressBar
 @onready var day_label  = $Control/DayLabel
 
-var current_day: int = 1
-
 func _ready() -> void:
-	#initialize the bar's maximum from the global quota and reset its current value
 	energy_bar.max_value = Global.energy_quota
-	energy_bar.set_energy(0)
-
 	Global.energy_changed.connect(fill)
-
-	#subscribe to day‑change if the signal exists in Global
-	#if Global.has_signal("day_changed"):
-		#Global.day_changed.connect(update_day)
-
-	# Show the initial day
-	update_day(current_day)
 
 
 func fill(current_quota: int) -> void:
 	energy_bar.animate_to(current_quota, anim_time)
 
-
 func _on_fill_button_pressed() -> void:
 	var target = energy_bar.value + step
 	energy_bar.animate_to(target, anim_time)
 
-
+# update the day counter
 func update_day(day: int) -> void:
-	#called when the day changes
-	#update the day label and reset the bar.
-	current_day = day
 	if day_label:
 		day_label.text = "Day %d" % day
-
-	# # Update max from global variable
-	# energy_bar.max_value = Global.energy_quota
-	# # Reset current energy value
-	# energy_bar.set_energy(0)
-	# # Emit energy reset so fill() animates bar back to zero
-	# Global.energy_changed.emit(0)

--- a/UI/energy-bar/energy-bar.tscn
+++ b/UI/energy-bar/energy-bar.tscn
@@ -29,10 +29,10 @@ scale = Vector2(0.5, 0.5)
 [node name="TextureProgressBar" type="TextureProgressBar" parent="CanvasLayer/Control"]
 z_index = 5
 layout_mode = 0
-offset_left = 193.925
-offset_top = 67.025
-offset_right = 503.925
-offset_bottom = 163.025
+offset_left = 156.0
+offset_top = 46.0
+offset_right = 404.0
+offset_bottom = 106.0
 value = 100.0
 nine_patch_stretch = true
 texture_progress = ExtResource("3_kdubu")
@@ -40,30 +40,30 @@ script = ExtResource("4_d21ai")
 
 [node name="Label" type="Label" parent="CanvasLayer/Control"]
 layout_mode = 0
-offset_left = 206.0
-offset_top = 202.0
-offset_right = 280.0
-offset_bottom = 230.0
+offset_left = 174.0
+offset_top = 130.0
+offset_right = 248.0
+offset_bottom = 166.0
 theme_override_font_sizes/font_size = 30
 text = "0 / 10"
 
 [node name="DayLabel" type="Label" parent="CanvasLayer/Control"]
 layout_mode = 0
-offset_left = 90.0
-offset_top = 218.0
-offset_right = 148.0
-offset_bottom = 250.0
+offset_left = 64.0
+offset_top = 142.0
+offset_right = 124.0
+offset_bottom = 217.0
 theme_override_font_sizes/font_size = 30
 text = "Day 1
 "
 
 [node name="Sprite2D" type="Sprite2D" parent="CanvasLayer/Control"]
-position = Vector2(277.925, 113.025)
-scale = Vector2(0.35, 0.35)
+position = Vector2(222, 73)
+scale = Vector2(0.272915, 0.202578)
 texture = ExtResource("2_q6r6c")
 
 [node name="Sprite2D2" type="Sprite2D" parent="CanvasLayer/Control"]
 z_index = 6
-position = Vector2(277.925, 113.025)
-scale = Vector2(0.35, 0.35)
+position = Vector2(221, 73)
+scale = Vector2(0.274294, 0.202578)
 texture = ExtResource("1_0hol4")

--- a/UI/energy-bar/energy-bar.tscn
+++ b/UI/energy-bar/energy-bar.tscn
@@ -45,7 +45,7 @@ offset_top = 202.0
 offset_right = 280.0
 offset_bottom = 230.0
 theme_override_font_sizes/font_size = 30
-text = "0 / 100"
+text = "0 / 10"
 
 [node name="DayLabel" type="Label" parent="CanvasLayer/Control"]
 layout_mode = 0

--- a/UI/energy-bar/texture_progress_bar.gd
+++ b/UI/energy-bar/texture_progress_bar.gd
@@ -1,8 +1,8 @@
 extends TextureProgressBar
 
-@export var max_energy: int = 100
+@export var max_energy: int = 10
 
-@export var label : Label
+@onready var label = $"../Label"
 
 func _ready() -> void:
 	max_value = max_energy


### PR DESCRIPTION
## Description
fixes the bug where the energy quota was hardcoded to 100, also interface was decreased

## Related Issue
[#62](https://github.com/TheTopSecretTeam/TheCOOrP/issues/62)
[#79](https://github.com/TheTopSecretTeam/TheCOOrP/issues/79)
[#82](https://github.com/TheTopSecretTeam/TheCOOrP/issues/82)
## Acceptance Criteria

Given the game is in progress  
When the energy bar is visible  
Then the current day number is displayed under the energy bar in the format: **Day X**, where X is the current in-game day number

Given the game is in progress  
When the energy bar is visible  
Then the current amount of collected energy and the energy quota are shown under the energy bar in the format: **(collected/quota)** — for example, (12/20)

Given the player collects energy or the day changes  
When the collected amount or day number updates  
Then the values displayed under the energy bar are updated immediately to reflect the current state

### Checklist
- [x] Code adheres to project style guidelines  
- [x] New and existing tests pass  
- [x] Documentation has been updated (in-code comments)  
- [ ] Necessary migrations or config changes included  
