### PR TITLE
Resource icon decrease size

### DIFF
--- a/UI/resource-display/resourse_box.tscn
+++ b/UI/resource-display/resourse_box.tscn
@@ -16,7 +16,7 @@ script = ExtResource("1_8jmiw")
 layout_mode = 2
 
 [node name="TextureRect" type="TextureRect" parent="ResourseSlot"]
-custom_minimum_size = Vector2(100, 100)
+custom_minimum_size = Vector2(50, 50)
 layout_mode = 2
 texture = ExtResource("2_xgr34")
 expand_mode = 1
@@ -28,7 +28,7 @@ layout_mode = 2
 layout_mode = 2
 
 [node name="TextureRect" type="TextureRect" parent="ResourseSlot2"]
-custom_minimum_size = Vector2(100, 100)
+custom_minimum_size = Vector2(50, 50)
 layout_mode = 2
 texture = ExtResource("3_s2ib2")
 expand_mode = 3
@@ -40,7 +40,7 @@ layout_mode = 2
 layout_mode = 2
 
 [node name="TextureRect" type="TextureRect" parent="ResourseSlot3"]
-custom_minimum_size = Vector2(100, 100)
+custom_minimum_size = Vector2(50, 50)
 layout_mode = 2
 texture = ExtResource("4_g2hgf")
 expand_mode = 3
@@ -52,7 +52,7 @@ layout_mode = 2
 layout_mode = 2
 
 [node name="TextureRect" type="TextureRect" parent="ResourseSlot4"]
-custom_minimum_size = Vector2(100, 100)
+custom_minimum_size = Vector2(50, 50)
 layout_mode = 2
 texture = ExtResource("5_r518q")
 expand_mode = 3


### PR DESCRIPTION
## Description
Descreased resource icons

## Related Issue
[#82](https://github.com/TheTopSecretTeam/TheCOOrP/issues/82)

## Acceptance Criteria

Given player interface
When it is displayed
Then it should be less than now (less on about 15-20%)


## Testing & Verification

1. Launch the gameplay scene.
2. After reducing the interface, the icons remained visible and understandable.

### Checklist

- [X] Code adheres to project style guidelines
- [X] New and existing tests pass
- [ ] Documentation has been updated (if needed)
- [ ] Necessary migrations or config changes included