### PR TITLE
Updated main menu

### DIFF
--- a/scenes/load_menu.tscn
+++ b/scenes/load_menu.tscn
@@ -1,0 +1,44 @@
+[gd_scene format=3 uid="uid://d0byn4o8mux4n"]
+
+[node name="LoadMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 0
+offset_left = 254.0
+offset_top = 58.0
+offset_right = 254.0
+offset_bottom = 207.0
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 0
+offset_top = 71.0
+offset_right = 530.0
+offset_bottom = 334.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="NewWorldButton1" type="Button" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(500, 0)
+layout_mode = 2
+text = "Empty"
+
+[node name="NewWorldButton2" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Empty"
+
+[node name="NewWorldButton3" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Empty"
+
+[node name="NewWorldButton4" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Empty"
+
+[node name="NewWorldButton5" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Empty"
+
+[node name="BackButton" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Back to Main Menu"

--- a/scenes/main_menu.gd
+++ b/scenes/main_menu.gd
@@ -8,7 +8,8 @@ func _ready() -> void:
 			btn.disabled = true
 
 func _on_Main_NewGame_pressed():
-	_mok_jmp_to_map()
+	pass
+	#_mok_jmp_to_map()
 	#$Main.hide()
 	#$NewGameMenu.show()
 
@@ -45,3 +46,7 @@ func _on_NG_Start_pressed():
 
 func _mok_jmp_to_map():
 	get_tree().change_scene_to_file("res://scenes/multiplayer.tscn")
+
+
+func _on_connect_button_pressed() -> void:
+	_mok_jmp_to_map()

--- a/scenes/main_menu.gd
+++ b/scenes/main_menu.gd
@@ -7,46 +7,17 @@ func _ready() -> void:
 		for btn in web_disable_list:
 			btn.disabled = true
 
-func _on_Main_NewGame_pressed():
-	pass
-	#_mok_jmp_to_map()
-	#$Main.hide()
-	#$NewGameMenu.show()
-
-func _on_Main_Load_pressed():
-	_mok_jmp_to_map()
-	#$Main.hide()
-	#$LoadMenu.show()
-
-func _on_Main_Settings_pressed():
-	print("Settings are not implemented")
-
-func _on_Main_Join_pressed():
-	get_tree().change_scene_to_file("res://scenes/map.tscn")
-
-func _on_Main_Exit_pressed():
-	$ExitDialog.popup_centered()
-
-func _on_Main_Exit_confirmed():
-	get_tree().quit()
-
-func _on_Load_NewWorld_pressed():
-	print("New World is not implemented")
-
-func _on_Load_Back_pressed():
-	$LoadMenu.hide()
-	$Main.show()
-
-func _on_NG_Back_pressed():
-	$NewGameMenu.hide()
-	$Main.show()
-
-func _on_NG_Start_pressed():
-	pass
-
-func _mok_jmp_to_map():
+func _on_Multiplayer_button_pressed() -> void:
 	get_tree().change_scene_to_file("res://scenes/multiplayer.tscn")
 
+func _on_Singleplayer_pressed():
+	get_tree().change_scene_to_file("res://scenes/map.tscn")
 
-func _on_connect_button_pressed() -> void:
-	_mok_jmp_to_map()
+func _on_Settings_pressed():
+	print("Settings are not implemented")
+
+func _on_Exit_pressed():
+	$ExitDialog.popup_centered()
+
+func _on_Exit_confirmed():
+	get_tree().quit()

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -1,18 +1,16 @@
-[gd_scene load_steps=3 format=3 uid="uid://b5ecpebjg8xfe"]
+[gd_scene load_steps=2 format=3 uid="uid://b5ecpebjg8xfe"]
 
 [ext_resource type="Script" uid="uid://5730nmdpn0qm" path="res://scenes/main_menu.gd" id="1_06t4h"]
-
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_06t4h"]
 
 [node name="MainMenu" type="Control" node_paths=PackedStringArray("web_disable_list")]
 layout_mode = 3
 anchors_preset = 0
 offset_left = 117.0
 offset_top = 70.0
-offset_right = 375.0
-offset_bottom = 255.0
+offset_right = 530.0
+offset_bottom = 292.0
 script = ExtResource("1_06t4h")
-web_disable_list = [NodePath("Main/VBoxContainer/NewGameButton"), NodePath("Main/VBoxContainer/LoadButton")]
+web_disable_list = [NodePath("Main/VBoxContainer/MultiplayerButton")]
 
 [node name="Main" type="HBoxContainer" parent="."]
 layout_mode = 0
@@ -30,22 +28,13 @@ text = "The COOrP"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="NewGameButton" type="Button" parent="Main/VBoxContainer"]
+[node name="MultiplayerButton" type="Button" parent="Main/VBoxContainer"]
 layout_mode = 2
-text = "New Game"
+text = "Multiplayer"
 
-[node name="ConnectButton" type="Button" parent="Main/VBoxContainer"]
+[node name="SingleplayerButton" type="Button" parent="Main/VBoxContainer"]
 layout_mode = 2
-text = "Connect
-"
-
-[node name="LoadButton" type="Button" parent="Main/VBoxContainer"]
-layout_mode = 2
-text = "Load"
-
-[node name="JoinButton" type="Button" parent="Main/VBoxContainer"]
-layout_mode = 2
-text = "Single Player"
+text = "Singleplayer"
 
 [node name="SettingsButton" type="Button" parent="Main/VBoxContainer"]
 layout_mode = 2
@@ -59,8 +48,11 @@ text = "Exit"
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Controls:
- - MMB - Zoom, Move Camera
+ - Scroll - Zoom
+ - MMB - Move Camera
  - LMB - Select
+ - Shift + LMB - Multiselect
+ - RMB - Send Agent
 You can click on:
  - Anomaly Chamber
  - Anomaly Name
@@ -73,113 +65,8 @@ ok_button_text = "Yes"
 dialog_text = "Are you sure you want to exit?"
 cancel_button_text = "No"
 
-[node name="LoadMenu" type="Control" parent="."]
-visible = false
-layout_mode = 2
-anchors_preset = 0
-offset_left = 254.0
-offset_top = 58.0
-offset_right = 254.0
-offset_bottom = 207.0
-
-[node name="MarginContainer" type="MarginContainer" parent="LoadMenu"]
-layout_mode = 0
-offset_top = 71.0
-offset_right = 530.0
-offset_bottom = 334.0
-
-[node name="VBoxContainer" type="VBoxContainer" parent="LoadMenu/MarginContainer"]
-layout_mode = 2
-alignment = 1
-
-[node name="NewWorldButton1" type="Button" parent="LoadMenu/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(500, 0)
-layout_mode = 2
-text = "Empty"
-
-[node name="NewWorldButton2" type="Button" parent="LoadMenu/MarginContainer/VBoxContainer"]
-layout_mode = 2
-text = "Empty"
-
-[node name="NewWorldButton3" type="Button" parent="LoadMenu/MarginContainer/VBoxContainer"]
-layout_mode = 2
-text = "Empty"
-
-[node name="NewWorldButton4" type="Button" parent="LoadMenu/MarginContainer/VBoxContainer"]
-layout_mode = 2
-text = "Empty"
-
-[node name="NewWorldButton5" type="Button" parent="LoadMenu/MarginContainer/VBoxContainer"]
-layout_mode = 2
-text = "Empty"
-
-[node name="BackButton" type="Button" parent="LoadMenu/MarginContainer/VBoxContainer"]
-layout_mode = 2
-text = "Back to Main Menu"
-
-[node name="NewGameMenu" type="Control" parent="."]
-visible = false
-anchors_preset = 0
-offset_left = 335.0
-offset_top = -39.0
-offset_right = 375.0
-offset_bottom = 1.0
-
-[node name="MarginContainer" type="MarginContainer" parent="NewGameMenu"]
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
-
-[node name="VBoxContainer" type="VBoxContainer" parent="NewGameMenu/MarginContainer"]
-layout_mode = 2
-alignment = 1
-
-[node name="LineEdit" type="LineEdit" parent="NewGameMenu/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(300, 0)
-layout_mode = 2
-text = "New game"
-placeholder_text = "New game"
-alignment = 1
-max_length = 300
-
-[node name="Label" type="Label" parent="NewGameMenu/MarginContainer/VBoxContainer"]
-layout_mode = 2
-text = "List of connected players:"
-
-[node name="PlayersContainer" type="PanelContainer" parent="NewGameMenu/MarginContainer/VBoxContainer"]
-layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxTexture_06t4h")
-
-[node name="VBoxContainer" type="VBoxContainer" parent="NewGameMenu/MarginContainer/VBoxContainer/PlayersContainer"]
-layout_mode = 2
-
-[node name="HBoxContainer" type="HBoxContainer" parent="NewGameMenu/MarginContainer/VBoxContainer/PlayersContainer/VBoxContainer"]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="NewGameMenu/MarginContainer/VBoxContainer/PlayersContainer/VBoxContainer/HBoxContainer"]
-layout_mode = 2
-text = "Imaginary Player Name"
-
-[node name="Bottom" type="HBoxContainer" parent="NewGameMenu/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(300, 0)
-layout_mode = 2
-alignment = 1
-
-[node name="BackButton" type="Button" parent="NewGameMenu/MarginContainer/VBoxContainer/Bottom"]
-layout_mode = 2
-text = "Back to Main Menu"
-
-[node name="StartButton" type="Button" parent="NewGameMenu/MarginContainer/VBoxContainer/Bottom"]
-layout_mode = 2
-text = "Start the game"
-
-[connection signal="pressed" from="Main/VBoxContainer/NewGameButton" to="." method="_on_Main_NewGame_pressed"]
-[connection signal="pressed" from="Main/VBoxContainer/ConnectButton" to="." method="_on_connect_button_pressed"]
-[connection signal="pressed" from="Main/VBoxContainer/LoadButton" to="." method="_on_Main_Load_pressed"]
-[connection signal="pressed" from="Main/VBoxContainer/JoinButton" to="." method="_on_Main_Join_pressed"]
-[connection signal="pressed" from="Main/VBoxContainer/SettingsButton" to="." method="_on_Main_Settings_pressed"]
-[connection signal="pressed" from="Main/VBoxContainer/ExitButton" to="." method="_on_Main_Exit_pressed"]
-[connection signal="confirmed" from="ExitDialog" to="." method="_on_Main_Exit_confirmed"]
-[connection signal="pressed" from="LoadMenu/MarginContainer/VBoxContainer/BackButton" to="." method="_on_Load_Back_pressed"]
-[connection signal="pressed" from="NewGameMenu/MarginContainer/VBoxContainer/Bottom/BackButton" to="." method="_on_NG_Back_pressed"]
-[connection signal="pressed" from="NewGameMenu/MarginContainer/VBoxContainer/Bottom/StartButton" to="." method="_on_NG_Start_pressed"]
+[connection signal="pressed" from="Main/VBoxContainer/MultiplayerButton" to="." method="_on_Multiplayer_button_pressed"]
+[connection signal="pressed" from="Main/VBoxContainer/SingleplayerButton" to="." method="_on_Singleplayer_pressed"]
+[connection signal="pressed" from="Main/VBoxContainer/SettingsButton" to="." method="_on_Settings_pressed"]
+[connection signal="pressed" from="Main/VBoxContainer/ExitButton" to="." method="_on_Exit_pressed"]
+[connection signal="confirmed" from="ExitDialog" to="." method="_on_Exit_confirmed"]

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -34,6 +34,11 @@ vertical_alignment = 1
 layout_mode = 2
 text = "New Game"
 
+[node name="ConnectButton" type="Button" parent="Main/VBoxContainer"]
+layout_mode = 2
+text = "Connect
+"
+
 [node name="LoadButton" type="Button" parent="Main/VBoxContainer"]
 layout_mode = 2
 text = "Load"
@@ -169,6 +174,7 @@ layout_mode = 2
 text = "Start the game"
 
 [connection signal="pressed" from="Main/VBoxContainer/NewGameButton" to="." method="_on_Main_NewGame_pressed"]
+[connection signal="pressed" from="Main/VBoxContainer/ConnectButton" to="." method="_on_connect_button_pressed"]
 [connection signal="pressed" from="Main/VBoxContainer/LoadButton" to="." method="_on_Main_Load_pressed"]
 [connection signal="pressed" from="Main/VBoxContainer/JoinButton" to="." method="_on_Main_Join_pressed"]
 [connection signal="pressed" from="Main/VBoxContainer/SettingsButton" to="." method="_on_Main_Settings_pressed"]

--- a/scenes/multiplayer.tscn
+++ b/scenes/multiplayer.tscn
@@ -15,6 +15,7 @@ grow_vertical = 2
 script = ExtResource("1_b0l6s")
 
 [node name="Host" type="Button" parent="."]
+visible = false
 layout_mode = 0
 offset_left = 85.0
 offset_top = 267.0
@@ -24,10 +25,10 @@ text = "Host"
 
 [node name="Connect" type="Button" parent="."]
 layout_mode = 0
-offset_left = 422.0
-offset_top = 268.0
-offset_right = 659.0
-offset_bottom = 340.0
+offset_left = 311.0
+offset_top = 272.0
+offset_right = 548.0
+offset_bottom = 344.0
 text = "Connect"
 
 [node name="name" type="LineEdit" parent="."]

--- a/scenes/new_game_menu.tscn
+++ b/scenes/new_game_menu.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=2 format=3 uid="uid://46jjftt8toe1"]
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_06t4h"]
+
+[node name="NewGameMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 0
+offset_left = 335.0
+offset_top = -39.0
+offset_right = 375.0
+offset_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="LineEdit" type="LineEdit" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(300, 0)
+layout_mode = 2
+text = "New game"
+placeholder_text = "New game"
+alignment = 1
+max_length = 300
+
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "List of connected players:"
+
+[node name="PlayersContainer" type="PanelContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxTexture_06t4h")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/PlayersContainer"]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/PlayersContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/PlayersContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Imaginary Player Name"
+
+[node name="Bottom" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(300, 0)
+layout_mode = 2
+alignment = 1
+
+[node name="BackButton" type="Button" parent="MarginContainer/VBoxContainer/Bottom"]
+layout_mode = 2
+text = "Back to Main Menu"
+
+[node name="StartButton" type="Button" parent="MarginContainer/VBoxContainer/Bottom"]
+layout_mode = 2
+text = "Start the game"


### PR DESCRIPTION
## Description
Added button "Connect" between "New game" and "Load", also removed button "Host" in connection menu

## Related Issue
[#109](https://github.com/TheTopSecretTeam/TheCOOrP/issues/109)
[#108](https://github.com/TheTopSecretTeam/TheCOOrP/issues/108)

## Acceptance Criteria
108:
Given the main menu is displayed
When the player looks between the "New Game" and "Load" buttons
Then they see a new button labeled "Connect"

Given the main menu is displayed
When the player clicks the "Connect" button
Then the connection menu is shown on the screen

109:
Given the player is in the connection menu
When the menu is displayed
Then the "Host" button is not visible

## Testing & Verification
108:
1. Launch the gameplay scene.
2. Press "Connect" button: verify the connection menu appears and shows on the screen.

109:
1. Launch the gameplay scene.
2. Open connection menu make sure that "Host" button is not visible
### Checklist

- [X] Code adheres to project style guidelines
- [X] New and existing tests pass
- [] Documentation has been updated (if needed)
- [] Necessary migrations or config changes included